### PR TITLE
CNMHome to update body if body of base is not null

### DIFF
--- a/src/CommNetManager/CNMHome.cs
+++ b/src/CommNetManager/CNMHome.cs
@@ -171,7 +171,8 @@ namespace CommNetManager
         /// </summary>
         protected override void Start()
         {
-            this.body = this.GetComponentInParent<CelestialBody>();
+            if (this.GetComponentInParent<CelestialBody>() != null)
+                this.body = this.GetComponentInParent<CelestialBody>();
             if ((UnityEngine.Object)this.nodeTransform == (UnityEngine.Object)null)
                 this.nodeTransform = this.transform;
             this.Initialize();


### PR DESCRIPTION
Hi, this change will ensure `CNMHome` will only update `body` if the base has non-null `body`. 

This is because CommNetConstellation mod will create an additional `CNMHomeComponent` instance and assign a celestial body, as such Mun to its `body`. However, without the change above, CommNetManager would overwrite `body` of the additional component with body of base that could be `null`.

Hope this clarifies.